### PR TITLE
Add detector_name for user to specify

### DIFF
--- a/examples/count_person/README.md
+++ b/examples/count_person/README.md
@@ -20,4 +20,4 @@ TO BE ADDED.
 You can simply use `bash run.sh` to run the example. Below are some arguments in `run.sh` you may want to change.
 * `--path`: your own video dataset path.
 * `--save_folder`: the folder that you preferred to save the query result.
-* `-y`: your pretrained yolox model path.
+* `-d`: your directory for all pretrained models.

--- a/examples/count_person/main.py
+++ b/examples/count_person/main.py
@@ -15,9 +15,9 @@ def make_parser():
         help="the folder to save the final result",
     )
     parser.add_argument(
-        "-y",
-        "--yolox_model_path",
-        help="path to yolox pretrained model")
+        "-d",
+        "--pretrained_model_dir",
+        help="Directory to pretrained models")
     return parser
 
 
@@ -70,10 +70,11 @@ class ListPersonOnCrosswalk(vqpy.QueryBase):
 
 if __name__ == '__main__':
     args = make_parser().parse_args()
-    register(YOLOXDetector)
+    register("yolox", YOLOXDetector, "yolox_x.pth")
     vqpy.launch(cls_name=vqpy.COCO_CLASSES,
                 cls_type={"person": Pedestrian},
                 tasks=[ListPersonOnCrosswalk()],
                 video_path=args.path,
                 save_folder=args.save_folder,
-                detector_model_path=args.yolox_model_path)
+                detector_name="yolox",
+                detector_model_dir=args.pretrained_model_dir)

--- a/examples/count_person/run.sh
+++ b/examples/count_person/run.sh
@@ -1,1 +1,1 @@
-python3 examples/count_person/main.py --path videos/auburn_raw000.mp4 --save_folder vqpy_outputs/count_person -y examples/yolo/pretrained/yolox_x.pth
+python3 examples/count_person/main.py --path videos/auburn_raw000.mp4 --save_folder vqpy_outputs/count_person -y examples/yolo/pretrained

--- a/examples/list_red_moving_vehicle/README.md
+++ b/examples/list_red_moving_vehicle/README.md
@@ -25,4 +25,4 @@ TO BE ADDED.
 You can simply use `bash run.sh` to run the example. Below are some arguments in `run.sh` you may want to change.
 * `--path`: your own video dataset path.
 * `--save_folder`: the folder that you preferred to save the query result.
-* `-y`: your pretrained yolox model path.
+* `-d`: your directory for all pretrained models.

--- a/examples/list_red_moving_vehicle/main.py
+++ b/examples/list_red_moving_vehicle/main.py
@@ -18,9 +18,9 @@ def make_parser():
         help="the folder to save the final result",
     )
     parser.add_argument(
-        "-y",
-        "--yolox_model_path",
-        help="path to yolox pretrained model")
+        "-d",
+        "--pretrained_model_dir",
+        help="Directory to pretrained models")
     return parser
 
 
@@ -69,10 +69,11 @@ class ListRedMovingVehicle(ListMovingVehicle):
 
 if __name__ == '__main__':
     args = make_parser().parse_args()
-    register(YOLOXDetector)
+    register("yolox", YOLOXDetector, "yolox_x.pth")
     vqpy.launch(cls_name=vqpy.COCO_CLASSES,
                 cls_type={"car": Vehicle, "truck": Vehicle},
                 tasks=[ListRedMovingVehicle()],
                 video_path=args.path,
                 save_folder=args.save_folder,
-                detector_model_path=args.yolox_model_path)
+                detector_name="yolox",
+                detector_model_dir=args.pretrained_model_dir)

--- a/examples/list_red_moving_vehicle/run.sh
+++ b/examples/list_red_moving_vehicle/run.sh
@@ -1,1 +1,1 @@
-python3 examples/list_red_moving_vehicle/main.py --path videos/demo.mp4 --save_folder vqpy_outputs/redmovings -y examples/yolo/pretrained/yolox_x.pth
+python3 examples/list_red_moving_vehicle/main.py --path videos/demo.mp4 --save_folder vqpy_outputs_new/redmovings -d /home/ubuntu/demo/examples/yolo/pretrained/

--- a/vqpy/__init__.py
+++ b/vqpy/__init__.py
@@ -26,7 +26,9 @@ def launch(cls_name,
            video_path: str,
            save_folder: str = None,
            save_freq: int = 10,
-           detector_model_path: str = None):
+           detector_model_dir: str = None,
+           detector_name: str = None,
+           ):
     """Launch the VQPy tasks with specific setting.
     Args:
         cls_name: the detector classification result classes.
@@ -35,12 +37,15 @@ def launch(cls_name,
         video_path (str): the path of the queried video.
         save_folder: the folder to save final result.
         save_freq: the frequency of save when processing.
-        detector_model_path: the pretrained detector path.
+        detector_model_dir: the directory for all pretrained detectors.
+        detector_name: the specific detector name you desire to use.
     """
     logger.info(f"VQPy Launch I/O Setting: \
                   video_path={video_path}, save_folder={save_folder}")
     stream = FrameStream(video_path)
-    detector = setup_detector(cls_name, detector_model_path)
+    detector = setup_detector(cls_name,
+                              detector_model_dir=detector_model_dir,
+                              detector_name=detector_name)
     # Now tracking is always performed by track each class separately
     tracker = MultiTracker(setup_ground_tracker, stream, cls_name, cls_type)
     for task in tasks:

--- a/vqpy/detector/__init__.py
+++ b/vqpy/detector/__init__.py
@@ -5,15 +5,29 @@ All visible instances in this folder inherits (base/detector.py).
 
 from .logger import vqpy_detectors
 from ..base.detector import DetectorBase
+import os
 
-# TODO: add automatic detector selection interface here
 
-
-def setup_detector(cls_names, detector_model_path) -> DetectorBase:
+def setup_detector(cls_names,
+                   detector_model_dir: str = None,
+                   detector_name: str = None,
+                   ) -> DetectorBase:
     """setup a detector for video analytics
     cls_names: the detection class types of the required detector
     """
-    for detector_type in vqpy_detectors:
-        # Optional TODO: add ambiguous class match here
-        if cls_names == detector_type.cls_names:
-            return detector_type(model_path=detector_model_path)
+    if detector_name:
+        if detector_name not in vqpy_detectors:
+            raise ValueError(f"Detector name of {detector_name} hasn't been"
+                             f"registered to VQPy")
+        detector_type, model_filename = vqpy_detectors[detector_name]
+
+    else:
+        # TODO: add automatic detector selection interface here
+        for detector_name in vqpy_detectors:
+            # Optional TODO: add ambiguous class match here
+            detector_type, model_filename = vqpy_detectors[detector_name]
+            if cls_names == detector_type.cls_names:
+                print(f"Detector {detector_name} has been selected!")
+                break
+    detector_model_path = os.path.join(detector_model_dir, model_filename)
+    return detector_type(model_path=detector_model_path)

--- a/vqpy/detector/logger.py
+++ b/vqpy/detector/logger.py
@@ -1,7 +1,11 @@
 """The logger for all VQPy detectors"""
 
-vqpy_detectors = []
+vqpy_detectors = {}
 
 
-def register(detector_type):
-    vqpy_detectors.append(detector_type)
+def register(detector_name, detector_type, model_filename):
+    detector_name_lower = detector_name.lower()
+    if detector_name_lower in vqpy_detectors:
+        raise ValueError(f"Detector name {detector_name} is already in VQPy."
+                         f"Please change another name to register.")
+    vqpy_detectors[detector_name_lower] = (detector_type, model_filename)


### PR DESCRIPTION
## Why this PR? 
This PR allows users to specify the detector name they want to use.
This PR is a pre-step for adding multiple detectors. Before we can automatically select the execution path, we can first choose detectors according to their names. 

## Changes in VQPy interface
In `vqpy.launch`: add `detector_name` and `detector_model_dir`. 
* `detector_name` is the specific detector that users desire to use for object detection. It can be either VQPy built-in detectors or user-defined detectors.
* `detector_model_dir`: the directory that contains the pre-trained models for all detectors. Note that users only need to prepare one pretrained model in the directory if they have the desired detector (specified in `detector_name`). It is a local dir for now, and later we can support remote directories. Users need to put their pretrained detector models in the `detector_model_dir`.
