### PR TITLE
Move bottom center coordinate to vqpy builtin function

### DIFF
--- a/examples/people_counting/people_counting.py
+++ b/examples/people_counting/people_counting.py
@@ -40,15 +40,9 @@ class CountPersonOnCrosswalk(vqpy.QueryBase):
                               (1839, 492), (1893, 547)]
         CROSSWALK_REGIONS = [CROSSWALK_REGION_1, CROSSWALK_REGION_2]
 
-        def get_bottom_central_point(tlbr):
-            x = (tlbr[0] + tlbr[2]) / 2
-            y = tlbr[3]
-            return (x, y)
-
-        def on_crosswalk(tlbr):
+        def on_crosswalk(bottom_center):
             from shapely.geometry import Point, Polygon
-            bottom_central_point = get_bottom_central_point(tlbr)
-            point = Point(bottom_central_point)
+            point = Point(bottom_center)
             for region in CROSSWALK_REGIONS:
                 poly = Polygon(region)
                 if point.within(poly):
@@ -56,7 +50,7 @@ class CountPersonOnCrosswalk(vqpy.QueryBase):
             return False
 
         filter_cons = {"__class__": lambda x: x == Person,
-                       "tlbr": on_crosswalk}
+                       "bottom_center": on_crosswalk}
         select_cons = {"track_id": None,
                        }
         return vqpy.VObjConstraint(filter_cons=filter_cons,

--- a/vqpy/function/functions.py
+++ b/vqpy/function/functions.py
@@ -44,3 +44,11 @@ def license_plate_openalpr(obj, image):
 def coordinate_center(obj, tlbr):
     """compute the center of the bounding box"""
     return (tlbr[:2] + tlbr[2:]) / 2
+
+
+@vqpy_func_logger(['tlbr'], ['bottom_center'], [], required_length=1)
+def bottom_center_coordinate(obj, tlbr):
+    """compute the coordinate of bottom center of the bounding box"""
+    x = (tlbr[0] + tlbr[2]) / 2
+    y = tlbr[3]
+    return [(x, y)]


### PR DESCRIPTION
## Why this change?
To ease user to compute bottom center coordinate of bounding box

## What does this PR include?
* Add a built-in vqpy function of `bottom_center_coordinate`

## User API changes
User can directly use "bottom_center" as the keywords in their `filter_cons` and `select_cons` when writing their query, without refine a function to compute the coordinate of the bottom center.

## New dependencies included
None