### PR TITLE
Support query on VObj satisfying condition for time period

### DIFF
--- a/examples/loitering/main.py
+++ b/examples/loitering/main.py
@@ -41,7 +41,7 @@ class People_loitering_query(vqpy.QueryBase):
             "track_id": None,
             "coordinate": lambda x: str(x),  # convert to string for
                                              # JSON serialization
-            # name in vqpy.continuing + '_duration' stored in VObj
+            # name in vqpy.continuing + '_periods' stored in VObj
             # can be accessed by getv, be used in select_cons, etc.
             "in_roi_periods": None,
         }

--- a/examples/loitering/main.py
+++ b/examples/loitering/main.py
@@ -1,0 +1,79 @@
+import argparse
+
+import vqpy
+from vqpy.detector.logger import register
+from yolox_detector import YOLOXDetector
+
+
+def make_parser():
+    parser = argparse.ArgumentParser("VQPy Demo!")
+    parser.add_argument("--path", help="path to video")
+    parser.add_argument(
+        "--save_folder",
+        default=None,
+        help="the folder to save the final result",
+    )
+    parser.add_argument(
+        "-d", "--pretrained_model_dir", help="Directory to pretrained models"
+    )
+    return parser
+
+
+class Person(vqpy.VObjBase):
+    @vqpy.property()
+    def coordinate_center(self):
+        tlbr = self.getv("tlbr")
+        if tlbr is not None:
+            return str((tlbr[:2] + tlbr[2:]) / 2)
+
+
+class People_loitering_query(vqpy.QueryBase):
+    @staticmethod
+    def setting() -> vqpy.VObjConstraint:
+        REGION = [
+            (550, 550), (1162, 400), (1720, 720), (1430, 1072), (600, 1073)
+            ]
+
+        def get_bottom_central_point(tlbr):
+            x = (tlbr[0] + tlbr[2]) / 2
+            y = tlbr[3]
+            return (x, y)
+
+        def in_region_of_interest(tlbr):
+            from shapely.geometry import Point, Polygon
+
+            botton_central_point = get_bottom_central_point(tlbr)
+            point = Point(botton_central_point)
+            poly = Polygon(REGION)
+            if point.within(poly):
+                return True
+            return False
+
+        filter_cons = {
+            "__class__": lambda x: x == Person,
+            "tlbr": vqpy.lasting(
+                trigger=in_region_of_interest, time=10, name="in_roi"
+            ),
+        }
+        select_cons = {
+            "coordinate_center": None,
+            "track_id": None,
+            "in_roi_time_periods": None,
+        }
+        return vqpy.VObjConstraint(
+            filter_cons, select_cons, filename="loitering"
+        )
+
+
+if __name__ == "__main__":
+    args = make_parser().parse_args()
+    register("yolox", YOLOXDetector, "yolox_x.pth")
+    vqpy.launch(
+        cls_name=vqpy.COCO_CLASSES,
+        cls_type={"person": Person},
+        tasks=[People_loitering_query()],
+        video_path=args.path,
+        save_folder=args.save_folder,
+        detector_name="yolox",
+        detector_model_dir=args.pretrained_model_dir,
+    )

--- a/examples/loitering/main.py
+++ b/examples/loitering/main.py
@@ -1,5 +1,4 @@
 import argparse
-
 import vqpy
 from vqpy.detector.logger import register
 from yolox_detector import YOLOXDetector
@@ -39,12 +38,12 @@ class People_loitering_query(vqpy.QueryBase):
             ),
         }
         select_cons = {
+            "track_id": None,
             "coordinate": lambda x: str(x),  # convert to string for
                                              # JSON serialization
-            "track_id": None,
             # name in vqpy.continuing + '_duration' stored in VObj
             # can be accessed by getv, be used in select_cons, etc.
-            "in_roi_duration": None,
+            "in_roi_periods": None,
         }
         return vqpy.VObjConstraint(
             filter_cons, select_cons, filename="loitering"

--- a/examples/loitering/main.py
+++ b/examples/loitering/main.py
@@ -33,26 +33,12 @@ class People_loitering_query(vqpy.QueryBase):
         REGION = [
             (550, 550), (1162, 400), (1720, 720), (1430, 1072), (600, 1073)
             ]
-
-        def get_bottom_central_point(tlbr):
-            x = (tlbr[0] + tlbr[2]) / 2
-            y = tlbr[3]
-            return (x, y)
-
-        def in_region_of_interest(tlbr):
-            from shapely.geometry import Point, Polygon
-
-            botton_central_point = get_bottom_central_point(tlbr)
-            point = Point(botton_central_point)
-            poly = Polygon(REGION)
-            if point.within(poly):
-                return True
-            return False
+        REGIONS = [REGION]
 
         filter_cons = {
             "__class__": lambda x: x == Person,
-            "tlbr": vqpy.utils.lasting(
-                trigger=in_region_of_interest, time=10, name="in_roi"
+            "bottom_center": vqpy.utils.lasting(
+                trigger=vqpy.utils.within_regions(REGIONS), time=10, name="in_roi"
             ),
         }
         select_cons = {

--- a/examples/loitering/main.py
+++ b/examples/loitering/main.py
@@ -58,6 +58,8 @@ class People_loitering_query(vqpy.QueryBase):
         select_cons = {
             "coordinate_center": None,
             "track_id": None,
+            # name in vqpy.lasting + '_time_periods' stored in VObj
+            # can be accessed by getv, be used in select_cons, etc.
             "in_roi_time_periods": None,
         }
         return vqpy.VObjConstraint(

--- a/examples/loitering/main.py
+++ b/examples/loitering/main.py
@@ -41,8 +41,7 @@ class People_loitering_query(vqpy.QueryBase):
             "track_id": None,
             "coordinate": lambda x: str(x),  # convert to string for
                                              # JSON serialization
-            # name in vqpy.continuing + '_periods' stored in VObj
-            # can be accessed by getv, be used in select_cons, etc.
+            # name in vqpy.continuing + '_periods' can be used in select_cons.
             "in_roi_periods": None,
         }
         return vqpy.VObjConstraint(

--- a/examples/loitering/main.py
+++ b/examples/loitering/main.py
@@ -37,17 +37,17 @@ class People_loitering_query(vqpy.QueryBase):
 
         filter_cons = {
             "__class__": lambda x: x == Person,
-            "bottom_center": vqpy.utils.lasting(
-                trigger=vqpy.utils.within_regions(REGIONS),
-                time=10, name="in_roi"
+            "bottom_center": vqpy.utils.continuing(
+                condition=vqpy.utils.within_regions(REGIONS),
+                duration=10, name="in_roi"
             ),
         }
         select_cons = {
             "coordinate_center": None,
             "track_id": None,
-            # name in vqpy.lasting + '_time_periods' stored in VObj
+            # name in vqpy.continuing + '_duration' stored in VObj
             # can be accessed by getv, be used in select_cons, etc.
-            "in_roi_time_periods": None,
+            "in_roi_duration": None,
         }
         return vqpy.VObjConstraint(
             filter_cons, select_cons, filename="loitering"

--- a/examples/loitering/main.py
+++ b/examples/loitering/main.py
@@ -38,7 +38,8 @@ class People_loitering_query(vqpy.QueryBase):
         filter_cons = {
             "__class__": lambda x: x == Person,
             "bottom_center": vqpy.utils.lasting(
-                trigger=vqpy.utils.within_regions(REGIONS), time=10, name="in_roi"
+                trigger=vqpy.utils.within_regions(REGIONS),
+                time=10, name="in_roi"
             ),
         }
         select_cons = {

--- a/examples/loitering/main.py
+++ b/examples/loitering/main.py
@@ -20,11 +20,7 @@ def make_parser():
 
 
 class Person(vqpy.VObjBase):
-    @vqpy.property()
-    def coordinate_center(self):
-        tlbr = self.getv("tlbr")
-        if tlbr is not None:
-            return str((tlbr[:2] + tlbr[2:]) / 2)
+    pass
 
 
 class People_loitering_query(vqpy.QueryBase):
@@ -43,7 +39,8 @@ class People_loitering_query(vqpy.QueryBase):
             ),
         }
         select_cons = {
-            "coordinate_center": None,
+            "coordinate": lambda x: str(x),  # convert to string for
+                                             # JSON serialization
             "track_id": None,
             # name in vqpy.continuing + '_duration' stored in VObj
             # can be accessed by getv, be used in select_cons, etc.

--- a/examples/loitering/yolox_detector.py
+++ b/examples/loitering/yolox_detector.py
@@ -1,0 +1,88 @@
+"""
+Based on demo implementation in Megvii YOLOX repo
+The YOLOX detector for object detection
+"""
+
+from typing import Dict, List
+
+import numpy as np
+import torch
+from loguru import logger
+from vqpy.base.detector import DetectorBase
+from vqpy.utils.classes import COCO_CLASSES
+
+from yolox.data.data_augment import ValTransform
+from yolox.exp.build import get_exp
+from yolox.utils import postprocess
+from yolox.utils.model_utils import get_model_info
+
+
+class YOLOXDetector(DetectorBase):
+    """The YOLOX detector for object detection"""
+
+    cls_names = COCO_CLASSES
+    output_fields = ["tlbr", "score", "class_id"]
+
+    def __init__(self, model_path, device="gpu", fp16=True):
+        # TODO: start a new process handling this
+        exp = get_exp(None, "yolox_x")
+        exp.test_conf = 0.3
+        exp.nmsthre = 0.3
+        exp.test_size = (640, 640)
+
+        model = exp.get_model()
+        model_info = get_model_info(model, exp.test_size)
+        logger.info(f"Model Summary: {model_info}")
+        if device == 'gpu':
+            model.cuda()
+            if fp16:
+                model.half()
+        model.eval()
+
+        logger.info("loading checkpoint")
+        ckpt = torch.load(model_path, map_location="cpu")
+        model.load_state_dict(ckpt["model"])
+        logger.info("loaded checkpoint done.")
+
+        self.model = model
+        self.num_classes = exp.num_classes
+        self.confthre = exp.test_conf
+        self.nmsthre = exp.nmsthre
+        self.test_size = exp.test_size
+        self.device = device
+        self.fp16 = fp16
+        self.preproc = ValTransform(legacy=False)
+        self.postproc = postprocess
+
+    def inference(self, img) -> List[Dict]:
+        ratio = min(self.test_size[0] / img.shape[0],
+                    self.test_size[1] / img.shape[1])
+
+        img, _ = self.preproc(img, None, self.test_size)
+        img = torch.from_numpy(img).unsqueeze(0)
+        img = img.float()
+        if self.device == "gpu":
+            img = img.cuda()
+            if self.fp16:
+                img = img.half()  # to FP16
+
+        with torch.no_grad():
+            outputs = self.model(img)
+            outputs = self.postproc(
+                outputs, self.num_classes, self.confthre,
+                self.nmsthre, class_agnostic=True
+            )
+
+        outputs = outputs[0]
+        if outputs is None:
+            return []
+        bboxes = (outputs[:, 0:4] / ratio).cpu()
+        scores = (outputs[:, 4:5] * outputs[:, 5:6]).cpu()
+        cls = outputs[:, 6:7].cpu()
+
+        rets = []
+        for (tlbr, score, class_id) in zip(bboxes, scores, cls):
+            rets.append({"tlbr": np.asarray(tlbr),
+                         "score": score.item(),
+                         "class_id": int(class_id.item())})
+        return rets

--- a/vqpy/__init__.py
+++ b/vqpy/__init__.py
@@ -19,6 +19,7 @@ from .base.interface import OutputConfig  # noqa: F401
 from .tracker import setup_ground_tracker
 from .utils.classes import COCO_CLASSES  # noqa: F401
 from .utils.video import FrameStream
+from .utils.filters import lasting  # noqa: F401
 
 
 def launch(cls_name,

--- a/vqpy/function/functions.py
+++ b/vqpy/function/functions.py
@@ -43,7 +43,7 @@ def license_plate_openalpr(obj, image):
 @vqpy_func_logger(['tlbr'], ['coordinate'], [], required_length=1)
 def coordinate_center(obj, tlbr):
     """compute the center of the bounding box"""
-    return (tlbr[:2] + tlbr[2:]) / 2
+    return [(tlbr[:2] + tlbr[2:]) / 2]
 
 
 @vqpy_func_logger(['tlbr'], ['bottom_center'], [], required_length=1)

--- a/vqpy/impl/vobj_base.py
+++ b/vqpy/impl/vobj_base.py
@@ -43,8 +43,8 @@ class VObjBase(VObjBaseInterface):
         """
         NOTE: Note the order in the following checking.
         Infer an attribute of the object from:
-        (1) _datas (2) __state_ (3) _ctx.output_fields (4) __record_
-        (5) _registered_names (6) vqpy.infer
+        (1) __static (2) _datas (3) __state_ (4) _ctx.output_fields
+        (5) __record_ (6) _registered_names (7) vqpy.infer
 
         attr: attribute name.
         index: FRAMEID - Current FRAMEID - 1.
@@ -54,8 +54,13 @@ class VObjBase(VObjBaseInterface):
         return: the value when applicable, and None otherwise.
 
         For paramterized getv, write UDFs to compute the required properties.
-        """
 
+        __static_ can be used to store properties that are not time-related.
+        e.g. color of object, aggregated properties
+        """
+        # patchwork to support __static_
+        if hasattr(self, '__static_' + attr):
+            return getattr(self, '__static_' + attr)
         idx = self._ctx.frame_id + index + 1 - self._start_idx
         if idx < 0 or idx > len(self._datas):
             return None

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -51,13 +51,13 @@ class VObjConstraint(VObjConstraintInterface):
         ret: List[VObjBaseInterface] = []
         for obj in objs:
             ok = True
-            for property, func in self.filter_cons.items():
-                # patch to support vqpy.utils.continuing since the object
-                # needs to be passed as an argument
+            for property_name, func in self.filter_cons.items():
+                # patch work to support vqpy.utils.continuing since Vobj needs
+                # to be passed as an argument
                 if type(func) == continuing:
-                    ok = func(obj, property)
+                    ok = func(obj, property_name)
                 else:
-                    it = obj.getv(property)
+                    it = obj.getv(property_name)
                     if it is None or not func(it):
                         ok = False
                         break

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -52,8 +52,8 @@ class VObjConstraint(VObjConstraintInterface):
         for obj in objs:
             ok = True
             for item, func in self.filter_cons.items():
-                # patch to support vqpy.utils.continuing since the object needs to
-                # be passed as an argument
+                # patch to support vqpy.utils.continuing since the object
+                # needs to be passed as an argument
                 if type(func) == continuing:
                     ok = func(obj, item)
                 else:

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 from typing import Callable, Dict, List, Optional
 from ..base.interface import VObjBaseInterface, VObjConstraintInterface
+from ..utils.filters import lasting
 
 
 class VObjConstraint(VObjConstraintInterface):
     """The constraint on VObj instances, helpful when applying queries"""
 
-    def __init__(self,
-                 filter_cons: Dict[str, Optional[Callable]] = {},
-                 select_cons: Dict[str, Optional[Callable]] = {},
-                 filename: str = "data"):
+    def __init__(
+        self,
+        filter_cons: Dict[str, Optional[Callable]] = {},
+        select_cons: Dict[str, Optional[Callable]] = {},
+        filename: str = "data",
+    ):
         """Initialize a VObj constraint instances
 
         filter_cons (Dict[str, Optional[Callable]], optional):
@@ -49,10 +52,13 @@ class VObjConstraint(VObjConstraintInterface):
         for obj in objs:
             ok = True
             for item, func in self.filter_cons.items():
-                it = obj.getv(item)
-                if it is None or not func(it):
-                    ok = False
-                    break
+                if type(func) == lasting:
+                    ok = func(obj, item)
+                else:
+                    it = obj.getv(item)
+                    if it is None or not func(it):
+                        ok = False
+                        break
             if ok:
                 ret.append(obj)
         return ret

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -52,6 +52,8 @@ class VObjConstraint(VObjConstraintInterface):
         for obj in objs:
             ok = True
             for item, func in self.filter_cons.items():
+                # patch to support vqpy.lasting since it's the object needs to
+                # be passed as an argument
                 if type(func) == lasting:
                     ok = func(obj, item)
                 else:

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Callable, Dict, List, Optional
 from ..base.interface import VObjBaseInterface, VObjConstraintInterface
-from ..utils.filters import lasting
+from ..utils.filters import continuing
 
 
 class VObjConstraint(VObjConstraintInterface):
@@ -52,9 +52,9 @@ class VObjConstraint(VObjConstraintInterface):
         for obj in objs:
             ok = True
             for item, func in self.filter_cons.items():
-                # patch to support vqpy.lasting since it's the object needs to
+                # patch to support vqpy.utils.continuing since the object needs to
                 # be passed as an argument
-                if type(func) == lasting:
+                if type(func) == continuing:
                     ok = func(obj, item)
                 else:
                     it = obj.getv(item)

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -51,13 +51,13 @@ class VObjConstraint(VObjConstraintInterface):
         ret: List[VObjBaseInterface] = []
         for obj in objs:
             ok = True
-            for item, func in self.filter_cons.items():
+            for property, func in self.filter_cons.items():
                 # patch to support vqpy.utils.continuing since the object
                 # needs to be passed as an argument
                 if type(func) == continuing:
-                    ok = func(obj, item)
+                    ok = func(obj, property)
                 else:
-                    it = obj.getv(item)
+                    it = obj.getv(property)
                     if it is None or not func(it):
                         ok = False
                         break

--- a/vqpy/utils/__init__.py
+++ b/vqpy/utils/__init__.py
@@ -5,4 +5,4 @@ some of the VQPy functions.
 """
 
 from .filters import lasting  # noqa: F401
-from .predicate_funcs import within_regions # noqa: F401
+from .predicate_funcs import within_regions  # noqa: F401

--- a/vqpy/utils/__init__.py
+++ b/vqpy/utils/__init__.py
@@ -4,5 +4,5 @@ These stuffs are not related to the VQPy feature, but is required by
 some of the VQPy functions.
 """
 
-from .filters import lasting  # noqa: F401
+from .filters import continuing  # noqa: F401
 from .predicate_funcs import within_regions  # noqa: F401

--- a/vqpy/utils/filters.py
+++ b/vqpy/utils/filters.py
@@ -51,7 +51,7 @@ class continuing:
                 period_end = cur_frame
             setattr(obj, f"__static_{self.name}_start", period_start)
             setattr(obj, f"__static_{self.name}_end", period_end)
-            if period_end - period_start >= self.duration:
+            if period_end - period_start >= self.duration * obj._ctx.fps:
                 time_period = (int(period_start / obj._ctx.fps),
                                int(period_end / obj._ctx.fps))
                 time_periods = obj.getv(f"{self.name}_periods")

--- a/vqpy/utils/filters.py
+++ b/vqpy/utils/filters.py
@@ -1,0 +1,20 @@
+class lasting:
+    def __init__(self, trigger, time, name):
+        self.trigger = trigger
+        self.time = time
+        self.name = f"{name}_time_periods"
+
+    def __call__(self, obj, item):
+        if self.trigger(obj.getv(item)):
+            found = False
+            for i in range(-1, -obj._track_length, -1):
+                time_period = obj.getv(self.name, i)
+                if time_period is not None:
+                    found = True
+                    obj._datas[-1][self.name] = time_period + 1
+                    if time_period >= self.time * obj._ctx.fps:
+                        return True
+                    break
+            if not found:
+                obj._datas[-1][self.name] = 1
+        return False

--- a/vqpy/utils/filters.py
+++ b/vqpy/utils/filters.py
@@ -1,20 +1,34 @@
 class lasting:
+    """A filter constraint that checks if the property is lasting for a
+    certain time period
+
+    Returns True if the `property` is True for the given time period,
+    with time period being counted accumulatively.
+    Attribute with name `property`_time_periods is used to store the
+    cumulative time period of condition being met.
+    """
+
     def __init__(self, trigger, time, name):
         self.trigger = trigger
         self.time = time
+        # use name given as property name of time periods
         self.name = f"{name}_time_periods"
 
     def __call__(self, obj, item):
         if self.trigger(obj.getv(item)):
+            # increment time period if `trigger` returns True
             found = False
+            # check frames from the last to the first
             for i in range(-1, -obj._track_length, -1):
                 time_period = obj.getv(self.name, i)
                 if time_period is not None:
+                    # increment time period
                     found = True
                     obj._datas[-1][self.name] = time_period + 1
                     if time_period >= self.time * obj._ctx.fps:
                         return True
                     break
             if not found:
+                # initialize time period if time_period attribute not found
                 obj._datas[-1][self.name] = 1
         return False

--- a/vqpy/utils/filters.py
+++ b/vqpy/utils/filters.py
@@ -1,11 +1,23 @@
 class continuing:
-    """A filter constraint that checks if the condition on property
-    is True for a certain duration
+    """Checks whether the condition function continues to be true
+    for a certain duration.
 
-    Returns True if the condition on `property` is True for the given
-    duration, with duration being counted accumulatively.
-    Attribute with name `property`_duration is used to store the
-    cumulative duration of condition being met.
+    Returns True if the `condition` function on `property` is True
+    for the given duration, with duration being counted accumulatively.
+
+    Cumulative duration (in number of frames) of condition being met
+    will be stored in VObj as a property, with name given by `name`
+    parameter as `f"{name}_duration"`. This property can be accessed
+    with getv, be used in select_cons, etc.
+
+    Attributes:
+    ----------
+    condition: func(property) -> bool
+        Condition function to be checked.
+    duration: int
+        Duration in seconds.
+    name: str
+        Name of the attribute to store the duration.
     """
 
     def __init__(self, condition, duration, name):
@@ -14,8 +26,8 @@ class continuing:
         # use name given as property name of duration
         self.name = f"{name}_duration"
 
-    def __call__(self, obj, item):
-        if self.condition(obj.getv(item)):
+    def __call__(self, obj, property):
+        if self.condition(obj.getv(property)):
             # increment duration if `condition` returns True
             found = False
             # check frames from the last to the first

--- a/vqpy/utils/filters.py
+++ b/vqpy/utils/filters.py
@@ -1,34 +1,34 @@
-class lasting:
-    """A filter constraint that checks if the property is lasting for a
-    certain time period
+class continuing:
+    """A filter constraint that checks if the condition on property
+    is True for a certain duration
 
-    Returns True if the `property` is True for the given time period,
-    with time period being counted accumulatively.
-    Attribute with name `property`_time_periods is used to store the
-    cumulative time period of condition being met.
+    Returns True if the condition on `property` is True for the given
+    duration, with duration being counted accumulatively.
+    Attribute with name `property`_duration is used to store the
+    cumulative duration of condition being met.
     """
 
-    def __init__(self, trigger, time, name):
-        self.trigger = trigger
-        self.time = time
-        # use name given as property name of time periods
-        self.name = f"{name}_time_periods"
+    def __init__(self, condition, duration, name):
+        self.condition = condition
+        self.duration = duration
+        # use name given as property name of duration
+        self.name = f"{name}_duration"
 
     def __call__(self, obj, item):
-        if self.trigger(obj.getv(item)):
-            # increment time period if `trigger` returns True
+        if self.condition(obj.getv(item)):
+            # increment duration if `condition` returns True
             found = False
             # check frames from the last to the first
             for i in range(-1, -obj._track_length, -1):
-                time_period = obj.getv(self.name, i)
-                if time_period is not None:
-                    # increment time period
+                duration = obj.getv(self.name, i)
+                if duration is not None:
+                    # increment duration
                     found = True
-                    obj._datas[-1][self.name] = time_period + 1
-                    if time_period >= self.time * obj._ctx.fps:
+                    obj._datas[-1][self.name] = duration + 1
+                    if duration >= self.duration * obj._ctx.fps:
                         return True
                     break
             if not found:
-                # initialize time period if time_period attribute not found
+                # initialize duration if duration attribute not found
                 obj._datas[-1][self.name] = 1
         return False


### PR DESCRIPTION
## Why this change?
Provide a convenient wrapper `vqpy.utils.continuing` around predicates to express queries about VObjs continuously satisfying the predicate.

## What does this PR include?
- implementation of `vqpy.utils.continuing`
- addition of field `__static_` to VObj for storing properties not related to time
- an example detecting people loitering utilizing `vqpy.utils.continuing`. The query filters `Person` objects inside the user-specified region for more than 10 seconds

## User API changes
This PR supports using `vqpy.utils.continuing` in queries to filter objects that has property continuously satisfying some condition for some duration.
```python
class MyQuery(vqpy.Query):
    @staticmethod
    def setting() -> vqpy.VObjConstraint:
        filter_cons = {
            "prop": vqpy.lasting(condition=func, duration=30, name="condition_name"),
        }
        select_cons = {
            "condition_name_periods": None
        }
        ...
```
Time periods of condition being met will be stored in VObj as a property with name of `f"{name}_periods"`, in format of a list of tuples `(start, end)`, where `start` and `end` are time relative to the start of video, in seconds. This property can be accessed with getv, be used in select_cons, etc.

## New dependencies included
None