### PR TITLE
Fix Vobjconstraint's merging logic when inheriting queries

### DIFF
--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -34,21 +34,16 @@ class VObjConstraint(VObjConstraintInterface):
 
     def __add__(self, other: VObjConstraint) -> VObjConstraint:
         """merge constraints in the form subclass + superclass"""
-        filter_cons = self.filter_cons
-        select_cons = self.select_cons
+        filter_cons = self.filter_cons.copy()
         # merge filter constraints
         for key, cond in other.filter_cons.items():
             if key in filter_cons:
                 filter_cons[key] = lambda x: filter_cons[key](x) and cond(x)
             else:
                 filter_cons[key] = cond
-        # prioritize select constraints in derived class, which is 'self'
-        # i.e. only add select constraints if not yet in self.select_cons
-        for key, postproc in other.select_cons.items():
-            if key not in select_cons:
-                select_cons[key] = postproc
-        ret = VObjConstraint(filter_cons, select_cons, self.filename)
-        return ret
+        # always use select_cons in derived class
+        select_cons = self.select_cons.copy()
+        return VObjConstraint(filter_cons, select_cons, self.filename)
 
     def filter(self, objs: List[VObjBaseInterface]) -> List[VObjBaseInterface]:
         """filter the list of vobjects from the constraint"""


### PR DESCRIPTION
## Why this change?
Query constructed with inheritance does not include filter conditions from its superclasses.

## What does this PR include?
Return merged filter_cons in VObjConstraint's `__add__` function.

## User API changes
None

## New dependencies included
None