### PR TITLE
Enhance `@cross_vobj_property`

### DIFF
--- a/examples/unattended_baggage/main.py
+++ b/examples/unattended_baggage/main.py
@@ -32,6 +32,7 @@ class Person(vqpy.VObjBase):
 
 
 class Baggage(vqpy.VObjBase):
+    @vqpy.stateful()
     @vqpy.cross_vobj_property(
         vobj_type=Person, vobj_num="ALL",
         vobj_input_fields=("track_id", "tlbr")

--- a/examples/unattended_baggage/main.py
+++ b/examples/unattended_baggage/main.py
@@ -48,13 +48,7 @@ class Baggage(vqpy.VObjBase):
         owner_id = None
         # with new implementation of @cross_vobj_property and VObj.update, only
         # tracked VObjs will go into the filter and compute property "owner"
-        # Thus baggage_tlbr will never be None
-        # # get list of person_ids
-        # person_ids = next(zip(*person_ids_tlbrs))
-        # # return previous owner, if baggage is not present in current frame
-        # # return None is previous owner is not present in current frame
-        # if baggage_tlbr is None:
-        #     return prev_owner if prev_owner in person_ids else None
+        # Thus no need to handle situation of baggage_tlbr being None
 
         # set threshold to baggage's width
         threshold = (baggage_tlbr[3] - baggage_tlbr[1])

--- a/examples/unattended_baggage/main.py
+++ b/examples/unattended_baggage/main.py
@@ -39,14 +39,15 @@ class Baggage(vqpy.VObjBase):
     )
     # function decorator responsible for retrieving list of properties
     # Person_id and Person_tlbr given as a list of track_id's and tlbr's
-    def owner(self, person_ids, person_tlbrs):
+    def owner(self, cross_vobj_args):
         # if previous owner within distance, return previous owner track id
         # else: find the nearest person within distance, return the track id
         # else: return None
         baggage_tlbr = self.getv('tlbr')
         prev_owner = self.getv('owner', -2)
         owner_id = None
-
+        # get list of person_ids
+        person_ids = next(zip(*cross_vobj_args))
         # return previous owner, if baggage is not present in current frame
         # return None is previous owner is not present in current frame
         if baggage_tlbr is None:
@@ -55,7 +56,7 @@ class Baggage(vqpy.VObjBase):
         # set threshold to baggage's width
         threshold = (baggage_tlbr[3] - baggage_tlbr[1])
         min_dist = threshold + 1
-        for person_id, person_tlbr in zip(person_ids, person_tlbrs):
+        for person_id, person_tlbr in cross_vobj_args:
             dist = distance(baggage_tlbr, person_tlbr)
             if person_id == prev_owner and dist <= threshold:
                 # return previous owner if still around

--- a/examples/unattended_baggage/main.py
+++ b/examples/unattended_baggage/main.py
@@ -32,7 +32,6 @@ class Person(vqpy.VObjBase):
 
 
 class Baggage(vqpy.VObjBase):
-    @vqpy.property()
     @vqpy.cross_vobj_property(
         vobj_type=Person, vobj_num="ALL",
         vobj_input_fields=("track_id", "tlbr")

--- a/examples/unattended_baggage/main.py
+++ b/examples/unattended_baggage/main.py
@@ -39,24 +39,27 @@ class Baggage(vqpy.VObjBase):
     )
     # function decorator responsible for retrieving list of properties
     # Person_id and Person_tlbr given as a list of track_id's and tlbr's
-    def owner(self, cross_vobj_args):
+    def owner(self, person_ids_tlbrs):
         # if previous owner within distance, return previous owner track id
         # else: find the nearest person within distance, return the track id
         # else: return None
         baggage_tlbr = self.getv('tlbr')
         prev_owner = self.getv('owner', -2)
         owner_id = None
-        # get list of person_ids
-        person_ids = next(zip(*cross_vobj_args))
-        # return previous owner, if baggage is not present in current frame
-        # return None is previous owner is not present in current frame
-        if baggage_tlbr is None:
-            return prev_owner if prev_owner in person_ids else None
+        # with new implementation of @cross_vobj_property and VObj.update, only
+        # tracked VObjs will go into the filter and compute property "owner"
+        # Thus baggage_tlbr will never be None
+        # # get list of person_ids
+        # person_ids = next(zip(*person_ids_tlbrs))
+        # # return previous owner, if baggage is not present in current frame
+        # # return None is previous owner is not present in current frame
+        # if baggage_tlbr is None:
+        #     return prev_owner if prev_owner in person_ids else None
 
         # set threshold to baggage's width
         threshold = (baggage_tlbr[3] - baggage_tlbr[1])
         min_dist = threshold + 1
-        for person_id, person_tlbr in cross_vobj_args:
+        for person_id, person_tlbr in person_ids_tlbrs:
             dist = distance(baggage_tlbr, person_tlbr)
             if person_id == prev_owner and dist <= threshold:
                 # return previous owner if still around

--- a/vqpy/__init__.py
+++ b/vqpy/__init__.py
@@ -60,9 +60,7 @@ def launch(cls_name,
     for frame_id in tqdm(range(1, stream.n_frames + 1)):
         frame_image = stream.next()
         outputs = detector.inference(frame_image)
-        _, _, frame = tracker.update(outputs, frame)
-        # frame contains all vobjs, enough for all queries
-        # we can drop the returned tracked/lost VObj list
+        frame = tracker.update(outputs, frame)
         for task in tasks:
             task.vqpy_update(frame)
 

--- a/vqpy/__init__.py
+++ b/vqpy/__init__.py
@@ -60,9 +60,9 @@ def launch(cls_name,
     for frame_id in tqdm(range(1, stream.n_frames + 1)):
         frame_image = stream.next()
         outputs = detector.inference(frame_image)
-        tracked_tracks, _, frame = tracker.update(outputs, frame)
+        _, _, frame = tracker.update(outputs, frame)    # frame contains all vobjs, enough for all queries
         for task in tasks:
-            task.vqpy_update(frame_id, tracked_tracks, frame)
+            task.vqpy_update(frame)
 
         if frame_id * save_freq >= tag and save_folder:
             if tag == stream.n_frames:

--- a/vqpy/__init__.py
+++ b/vqpy/__init__.py
@@ -60,7 +60,9 @@ def launch(cls_name,
     for frame_id in tqdm(range(1, stream.n_frames + 1)):
         frame_image = stream.next()
         outputs = detector.inference(frame_image)
-        _, _, frame = tracker.update(outputs, frame)    # frame contains all vobjs, enough for all queries
+        _, _, frame = tracker.update(outputs, frame)
+        # frame contains all vobjs, enough for all queries
+        # we can drop the returned tracked/lost VObj list
         for task in tasks:
             task.vqpy_update(frame)
 

--- a/vqpy/__init__.py
+++ b/vqpy/__init__.py
@@ -62,7 +62,7 @@ def launch(cls_name,
         outputs = detector.inference(frame_image)
         tracked_tracks, _, frame = tracker.update(outputs, frame)
         for task in tasks:
-            task.vqpy_update(frame_id, tracked_tracks)
+            task.vqpy_update(frame_id, tracked_tracks, frame)
 
         if frame_id * save_freq >= tag and save_folder:
             if tag == stream.n_frames:

--- a/vqpy/base/interface.py
+++ b/vqpy/base/interface.py
@@ -72,6 +72,13 @@ class VObjConstraintInterface(object):
         """apply the constraint on a list of VObj instances"""
         raise NotImplementedError
 
+    def _compute_cross_vobj_property(
+        self, frame: FrameInterface, vobjs: VObjBaseInterface, conditions
+    ) -> None:
+        """Compute cross_vobj_property's used in the conditions for the given
+        VObjs"""
+        raise NotImplementedError
+
 
 class FrameInterface(object):
     def __init__(self, ctx: FrameStream):

--- a/vqpy/base/interface.py
+++ b/vqpy/base/interface.py
@@ -1,7 +1,7 @@
 """Interfaces that requires implementations in impl/"""
 
 from __future__ import annotations
-from typing import Dict, List, Optional, Callable, Set
+from typing import Dict, List, Optional, Callable, Set, Tuple
 
 from ..utils.video import FrameStream
 
@@ -28,7 +28,7 @@ class VObjBaseInterface(object):
     def getv(self,
              attr: str,
              index: int = -1,
-             frame: Optional[FrameInterface] = None,
+             cross_vobj_args: Optional[Tuple] = None,
              specifications: Optional[Dict[str, str]] = None):
         """
         attr: attribute name.
@@ -61,7 +61,7 @@ class VObjConstraintInterface(object):
         """merge constraints in the form subclass + superclass"""
         raise NotImplementedError
 
-    def filter(self, objs: List[VObjBaseInterface], frame: FrameInterface) -> List[VObjBaseInterface]:
+    def filter(self, frame: FrameInterface) -> List[VObjBaseInterface]:
         """filter the list of vobjects from the constraint"""
         raise NotImplementedError
 
@@ -69,7 +69,7 @@ class VObjConstraintInterface(object):
         """select one vobject from the constraint"""
         raise NotImplementedError
     
-    def apply(self, vobjs: List[VObjBaseInterface], frame: FrameInterface) -> List[Dict]:
+    def apply(self, frame: FrameInterface) -> List[Dict]:
         """apply the constraint on a list of VObj instances"""
         raise NotImplementedError
 

--- a/vqpy/base/interface.py
+++ b/vqpy/base/interface.py
@@ -28,6 +28,7 @@ class VObjBaseInterface(object):
     def getv(self,
              attr: str,
              index: int = -1,
+             frame: Optional[FrameInterface] = None,
              specifications: Optional[Dict[str, str]] = None):
         """
         attr: attribute name.
@@ -60,11 +61,15 @@ class VObjConstraintInterface(object):
         """merge constraints in the form subclass + superclass"""
         raise NotImplementedError
 
-    def filter(self, objs: List[VObjBaseInterface]) -> List[VObjBaseInterface]:
+    def filter(self, objs: List[VObjBaseInterface], frame: FrameInterface) -> List[VObjBaseInterface]:
         """filter the list of vobjects from the constraint"""
         raise NotImplementedError
 
-    def apply(self, vobjs: List[VObjBaseInterface]) -> List[Dict]:
+    def select(self, objs: List[VObjBaseInterface]) -> VObjBaseInterface:
+        """select one vobject from the constraint"""
+        raise NotImplementedError
+    
+    def apply(self, vobjs: List[VObjBaseInterface], frame: FrameInterface) -> List[Dict]:
         """apply the constraint on a list of VObj instances"""
         raise NotImplementedError
 

--- a/vqpy/base/interface.py
+++ b/vqpy/base/interface.py
@@ -64,7 +64,8 @@ class VObjConstraintInterface(object):
         """filter the list of vobjects from the constraint"""
         raise NotImplementedError
 
-    def select(self, objs: List[VObjBaseInterface]) -> VObjBaseInterface:
+    def select(self, objs: List[VObjBaseInterface], frame: FrameInterface) \
+            -> VObjBaseInterface:
         """select one vobject from the constraint"""
         raise NotImplementedError
 

--- a/vqpy/base/interface.py
+++ b/vqpy/base/interface.py
@@ -13,10 +13,9 @@ class VObjBaseInterface(object):
     The tracker is responsible to keep objects updated when the track is active
     """
 
-    def __init__(self, frame: FrameInterface):
-        self._frame = frame
-        self._ctx = frame.ctx
-        self._start_idx = frame.ctx.frame_id
+    def __init__(self, ctx: FrameStream):
+        self._ctx = ctx
+        self._start_idx = ctx.frame_id
         # Number of frames consecutively appears
         self._track_length = 0
         # Historic object data. TODO: shrink memory

--- a/vqpy/base/interface.py
+++ b/vqpy/base/interface.py
@@ -23,6 +23,7 @@ class VObjBaseInterface(object):
         self._datas: List[Optional[Dict]] = []
         # List of @property instances
         self._registered_names: List[str] = []
+        self._registered_names_type: Dict[str, str] = {}
         raise NotImplementedError
 
     def getv(self,

--- a/vqpy/base/interface.py
+++ b/vqpy/base/interface.py
@@ -28,7 +28,6 @@ class VObjBaseInterface(object):
     def getv(self,
              attr: str,
              index: int = -1,
-             cross_vobj_args: Optional[Tuple] = None,
              specifications: Optional[Dict[str, str]] = None):
         """
         attr: attribute name.

--- a/vqpy/base/interface.py
+++ b/vqpy/base/interface.py
@@ -1,7 +1,7 @@
 """Interfaces that requires implementations in impl/"""
 
 from __future__ import annotations
-from typing import Dict, List, Optional, Callable
+from typing import Dict, List, Optional, Callable, Set
 
 from ..utils.video import FrameStream
 
@@ -21,8 +21,8 @@ class VObjBaseInterface(object):
         # Historic object data. TODO: shrink memory
         self._datas: List[Optional[Dict]] = []
         # List of @property instances
-        self._registered_names: List[str] = []
-        self._registered_names_type: Dict[str, str] = {}
+        self._registered_names: Set[str] = set()
+        self._registered_cross_vobj_names: Set[str] = set()
         raise NotImplementedError
 
     def getv(self,

--- a/vqpy/base/interface.py
+++ b/vqpy/base/interface.py
@@ -1,7 +1,7 @@
 """Interfaces that requires implementations in impl/"""
 
 from __future__ import annotations
-from typing import Dict, List, Optional, Callable, Set, Tuple
+from typing import Dict, List, Optional, Callable, Set
 
 from ..utils.video import FrameStream
 
@@ -67,7 +67,7 @@ class VObjConstraintInterface(object):
     def select(self, objs: List[VObjBaseInterface]) -> VObjBaseInterface:
         """select one vobject from the constraint"""
         raise NotImplementedError
-    
+
     def apply(self, frame: FrameInterface) -> List[Dict]:
         """apply the constraint on a list of VObj instances"""
         raise NotImplementedError

--- a/vqpy/base/query.py
+++ b/vqpy/base/query.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List, Dict
 from ..base.interface import (
-    VObjBaseInterface,
     VObjConstraintInterface,
-    VObjGeneratorType,
     OutputConfig,
     FrameInterface
 )

--- a/vqpy/base/query.py
+++ b/vqpy/base/query.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Dict
 from ..base.interface import (
     VObjBaseInterface,
     VObjConstraintInterface,
+    VObjGeneratorType,
     OutputConfig,
     FrameInterface
 )
@@ -33,11 +34,9 @@ class QueryBase(object):
         self._output_configs = self.set_output_configs()
         self._total_ids = set()
 
-    def vqpy_update(self,
-                    frame_id: int,
-                    vobjs: List[VObjBaseInterface],
-                    frame: FrameInterface):
-        data, filtered_ids = self._setting.apply(vobjs, frame)
+    def vqpy_update(self, frame: FrameInterface):
+        frame_id: int = frame.ctx.frame_id
+        data, filtered_ids = self._setting.apply(frame)
 
         # total vobj num is always the first element of output
         if self._output_configs.output_total_vobj_num:

--- a/vqpy/base/query.py
+++ b/vqpy/base/query.py
@@ -6,7 +6,8 @@ from typing import List
 from ..base.interface import (
     VObjBaseInterface,
     VObjConstraintInterface,
-    OutputConfig
+    OutputConfig,
+    FrameInterface
 )
 
 
@@ -34,8 +35,9 @@ class QueryBase(object):
 
     def vqpy_update(self,
                     frame_id: int,
-                    vobjs: List[VObjBaseInterface]):
-        data, filtered_ids = self._setting.apply(vobjs)
+                    vobjs: List[VObjBaseInterface],
+                    frame: FrameInterface):
+        data, filtered_ids = self._setting.apply(vobjs, frame)
 
         # total vobj num is always the first element of output
         if self._output_configs.output_total_vobj_num:

--- a/vqpy/base/surface_tracker.py
+++ b/vqpy/base/surface_tracker.py
@@ -1,8 +1,8 @@
 """the surface-level tracker base class"""
 
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
-from ..base.interface import VObjBaseInterface
+from ..base.interface import FrameInterface
 
 
 class SurfaceTrackerBase(object):
@@ -13,8 +13,7 @@ class SurfaceTrackerBase(object):
 
     input_fields = []       # the required data fields for this tracker
 
-    def update(self, data: List[Dict]
-               ) -> Tuple[List[VObjBaseInterface], List[VObjBaseInterface]]:
+    def update(self, data: List[Dict]) -> FrameInterface:
         """Generate the video objects using ground tracker and detection result
         returns: the current tracked/lost VObj instances"""
         raise NotImplementedError

--- a/vqpy/feat/feat.py
+++ b/vqpy/feat/feat.py
@@ -121,9 +121,13 @@ def cross_vobj_property(
         ):
     """Decorator for cross-object property computation.
 
-    Wrapper for cross-object property computation. Retrieves list of properties
-    of VObjs of specified type and passes them to the function, as
-    `List[Tuple(property1, property2, ...), ...]`
+    Wrapper for cross-object property computation. Retrieves `cross_vobj_arg`,
+    a list of properties of VObjs of specified type, and passes them to the
+    function being decorated. `cross_vobj_arg` has structure:
+    `List[Tuple(property1, property2, ...) for vobj1, Tuple for vobj2, ...]`.
+
+    The function that computes the property should accept two arguments:
+    `self` and `cross_vobj_arg` (positional).
 
     Attributes:
     vobj_type: VObjGeneratorType

--- a/vqpy/feat/feat.py
+++ b/vqpy/feat/feat.py
@@ -137,10 +137,10 @@ def cross_vobj_property(
     # other possible options could be user-specified number
     def wrap(func: Callable):
         @functools.wraps(func)
-        def wrapped_func(self: VObjBaseInterface, *args, **kwargs):
+        def wrapped_func(self: VObjBaseInterface, frame):
             # somehow find all vobjs of specified type and their properties
             # pass the properties to func and return value
-            vobjs = self._frame.get_tracked_vobjs(vobj_type)
+            vobjs = frame.get_tracked_vobjs(vobj_type)
             arg = tuple()
             for input_field in vobj_input_fields:
                 properties = []

--- a/vqpy/feat/feat.py
+++ b/vqpy/feat/feat.py
@@ -121,13 +121,17 @@ def cross_vobj_property(
         ):
     """Decorator for cross-object property computation.
 
-    Wrapper for cross-object property computation. Retrieves `cross_vobj_arg`,
-    a list of properties of VObjs of specified type, and passes them to the
-    function being decorated. `cross_vobj_arg` has structure:
-    `List[Tuple(property1, property2, ...) for vobj1, Tuple for vobj2, ...]`.
+    Wrapper for cross-object property computation.
 
-    The function that computes the property should accept two arguments:
+    The property function being decorated should accept two arguments:
     `self` and `cross_vobj_arg` (positional).
+    During execution, VQPy will pass `cross_vobj_arg`, a list of properties of
+    VObjs of specified type, to the property function being decorated.
+
+    `cross_vobj_arg` has structure:
+    `List[Tuple(property1, property2, ...) for vobj1, Tuple for vobj2, ...]`,
+    where property1, property2 are values of property names listed in
+    `vobj_input_fields`, in order; vobj1, vobj2 are VObjs of type `vobj_type`.
 
     Attributes:
     vobj_type: VObjGeneratorType

--- a/vqpy/feat/feat.py
+++ b/vqpy/feat/feat.py
@@ -137,11 +137,13 @@ def cross_vobj_property(
     # other possible options could be user-specified number
     def wrap(func: Callable):
         @functools.wraps(func)
-        def wrapped_func(self: VObjBaseInterface, cross_vobj_arg: Optional[List] = None):
-            # somehow find all vobjs of specified type and their properties
-            # pass the properties to func and return value
-            # parameter other_vobjs has default value None in order to maintain "same" interface with @property
-            # this compatibility is mainly used in VObjBase.__init__ at instance()
+        def wrapped_func(
+            self: VObjBaseInterface,
+            cross_vobj_arg: Optional[List] = None
+        ):
+            # parameter cross_vobj_arg has default value None to maintain
+            # the "same" interface with @property upon being called directly
+            # this compatibility is used in VObjBase.__init__ at instance()
             if len(self._datas) > 0:
                 vidx = '__record_' + func.__name__
                 aidx = '__index_' + func.__name__
@@ -154,8 +156,9 @@ def cross_vobj_property(
                     return value
             elif func.__name__ not in self._registered_cross_vobj_names:
                 # initialization
-                # register function name, required VObj type and required fields
-                self._registered_cross_vobj_names[func.__name__] = (vobj_type, vobj_input_fields)
+                # register function name, required VObj type and fields
+                self._registered_cross_vobj_names[func.__name__] = \
+                    (vobj_type, vobj_input_fields)
                 return None
         return wrapped_func
     return wrap

--- a/vqpy/feat/feat.py
+++ b/vqpy/feat/feat.py
@@ -123,7 +123,7 @@ def cross_vobj_property(
 
     Wrapper for cross-object property computation. Retrieves list of properties
     of VObjs of specified type and passes them to the function, as
-    `List[property1], List[property2], ...`.
+    `List[Tuple(property1, property2, ...), ...]`
 
     Attributes:
     vobj_type: VObjGeneratorType
@@ -137,7 +137,7 @@ def cross_vobj_property(
     # other possible options could be user-specified number
     def wrap(func: Callable):
         @functools.wraps(func)
-        def wrapped_func(self: VObjBaseInterface, *arg):
+        def wrapped_func(self: VObjBaseInterface, cross_vobj_arg: Optional[List] = None):
             # somehow find all vobjs of specified type and their properties
             # pass the properties to func and return value
             # parameter other_vobjs has default value None in order to maintain "same" interface with @property
@@ -148,7 +148,7 @@ def cross_vobj_property(
                 if getattr(self, aidx, None) == self._ctx.frame_id:
                     return getattr(self, vidx)
                 else:
-                    value = func(self, *arg)
+                    value = func(self, cross_vobj_arg)
                     setattr(self, vidx, value)
                     setattr(self, aidx, self._ctx.frame_id)
                     return value

--- a/vqpy/feat/feat.py
+++ b/vqpy/feat/feat.py
@@ -140,6 +140,8 @@ def cross_vobj_property(
         def wrapped_func(self: VObjBaseInterface, frame=None):
             # somehow find all vobjs of specified type and their properties
             # pass the properties to func and return value
+            # parameter frame has default value None in order to maintain "same" interface with @property
+            # this compatibility is mainly used in VObjBase.__init__
             if len(self._datas) > 0:
                 vobjs = frame.get_tracked_vobjs(vobj_type)
                 arg = tuple()

--- a/vqpy/feat/feat.py
+++ b/vqpy/feat/feat.py
@@ -30,6 +30,7 @@ def property():
             elif func.__name__ not in self._registered_names:
                 # initialization
                 self._registered_names.append(func.__name__)
+                self._registered_names_type[func.__name__] = 'property'
                 return None
         return wrapper
     return decorator
@@ -162,6 +163,7 @@ def cross_vobj_property(
             elif func.__name__ not in self._registered_names:
                 # initialization
                 self._registered_names.append(func.__name__)
+                self._registered_names_type[func.__name__] = 'cross_vobj_property'
                 return None
         return wrapped_func
     return wrap

--- a/vqpy/feat/feat.py
+++ b/vqpy/feat/feat.py
@@ -29,8 +29,7 @@ def property():
                     return value
             elif func.__name__ not in self._registered_names:
                 # initialization
-                self._registered_names.append(func.__name__)
-                self._registered_names_type[func.__name__] = 'property'
+                self._registered_names.add(func.__name__)
                 return None
         return wrapper
     return decorator
@@ -160,10 +159,9 @@ def cross_vobj_property(
                     setattr(self, vidx, value)
                     setattr(self, aidx, self._ctx.frame_id)
                     return value
-            elif func.__name__ not in self._registered_names:
+            elif func.__name__ not in self._registered_cross_vobj_names:
                 # initialization
-                self._registered_names.append(func.__name__)
-                self._registered_names_type[func.__name__] = 'cross_vobj_property'
+                self._registered_cross_vobj_names.add(func.__name__)
                 return None
         return wrapped_func
     return wrap

--- a/vqpy/impl/frame.py
+++ b/vqpy/impl/frame.py
@@ -25,13 +25,8 @@ class Frame:
                      ):
         # create new vobj if doesn't exist
         if track_id not in self.vobjs[vobj_type]:
-            # each vobj has reference to Frame
-            # temporary, should be querying on Frame
-            new_vobj = vobj_type(self)
+            new_vobj = vobj_type(self.ctx)
             self.vobjs[vobj_type][track_id] = new_vobj
-        else:
-            # update _frame if vobj already exists
-            self.vobjs[vobj_type][track_id]._frame = self
         # update vobj
         vobj = self.vobjs[vobj_type][track_id]
         vobj.update(data, self)

--- a/vqpy/impl/frame.py
+++ b/vqpy/impl/frame.py
@@ -34,7 +34,7 @@ class Frame:
             self.vobjs[vobj_type][track_id]._frame = self
         # update vobj
         vobj = self.vobjs[vobj_type][track_id]
-        vobj.update(data)
+        vobj.update(data, self)
 
         # update tracked and lost vobjs
         if data:

--- a/vqpy/impl/frame.py
+++ b/vqpy/impl/frame.py
@@ -29,7 +29,7 @@ class Frame:
             self.vobjs[vobj_type][track_id] = new_vobj
         # update vobj
         vobj = self.vobjs[vobj_type][track_id]
-        vobj.update(data, self)
+        vobj.update(data)
 
         # update tracked and lost vobjs
         if data:

--- a/vqpy/impl/multiclass_tracker.py
+++ b/vqpy/impl/multiclass_tracker.py
@@ -2,7 +2,7 @@
 this tracker separate objects by their classes, and tracks individually
 """
 
-from typing import Callable, Dict, List, Mapping, Tuple
+from typing import Callable, Dict, List, Mapping
 from ..base.ground_tracker import GroundTrackerBase
 from ..base.surface_tracker import SurfaceTrackerBase
 
@@ -29,13 +29,10 @@ class MultiTracker(SurfaceTrackerBase):
         self.tracker_dict: Dict[VObjGeneratorType, GroundTrackerBase] = {}
         self.vobj_pool: Dict[int, VObjBase] = {}
 
-    def update(self, output: List[Dict], last_frame: Frame
-               ) -> Tuple[List[VObjBase], List[VObjBase], Frame]:
+    def update(self, output: List[Dict], last_frame: Frame) -> Frame:
         """Generate the video objects using ground tracker and detection result
         returns: the current tracked/lost VObj instances"""
         detections: Dict[VObjGeneratorType, List[Dict]] = {}
-        tracked: List[VObjBase] = []
-        lost: List[VObjBase] = []
 
         last_frame_vobjs = last_frame.vobjs
         ctx = last_frame.ctx
@@ -65,10 +62,8 @@ class MultiTracker(SurfaceTrackerBase):
             for item in f_tracked:
                 track_id = item['track_id']
                 frame.update_vobjs(func, track_id, item)
-            tracked = frame.get_tracked_vobjs(func)
             for item in f_lost:
                 track_id = item['track_id']
                 frame.update_vobjs(func, track_id, None)
-            lost = frame.get_lost_vobjs(func)
             # logger.info(f"tracking done")
-        return tracked, lost, frame
+        return frame

--- a/vqpy/impl/vobj_base.py
+++ b/vqpy/impl/vobj_base.py
@@ -1,10 +1,9 @@
 """VObjBase implementation"""
 
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 
 from ..base.interface import VObjBaseInterface
 from ..function import infer
-from ..impl.frame import Frame
 from ..utils.video import FrameStream
 
 
@@ -59,8 +58,9 @@ class VObjBase(VObjBaseInterface):
 
         __static_ can be used to store properties that are not time-related.
         e.g. color of object, aggregated properties
-        
-        frame: the frame to be used for inference, used when the attribute is decorated with @cross_vobj_property
+
+        frame: the frame to be used for inference,used when the property is
+        decorated with @cross_vobj_property
         """
         # patchwork to support __static_
         if hasattr(self, '__static_' + attr):

--- a/vqpy/impl/vobj_base.py
+++ b/vqpy/impl/vobj_base.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional
 from ..base.interface import VObjBaseInterface
 from ..function import infer
 from ..impl.frame import Frame
+from ..utils.video import FrameStream
 
 
 class VObjBase(VObjBaseInterface):
@@ -12,10 +13,9 @@ class VObjBase(VObjBaseInterface):
     The tracker is responsible to keep objects updated when the track is active
     """
 
-    def __init__(self, frame: Frame):
-        self._frame = frame
-        self._ctx = frame.ctx
-        self._start_idx = frame.ctx.frame_id
+    def __init__(self, ctx: FrameStream):
+        self._ctx = ctx
+        self._start_idx = ctx.frame_id
         self._track_length = 0
         self._datas: List[Optional[Dict]] = []
         self._registered_names: List[str] = []

--- a/vqpy/impl/vobj_base.py
+++ b/vqpy/impl/vobj_base.py
@@ -77,9 +77,11 @@ class VObjBase(VObjBaseInterface):
                   getattr(self, '__index_' + attr) == self._ctx.frame_id):
                 return getattr(self, '__record_' + attr)
             elif attr in self._registered_names:
-                if 'frame' in inspect.signature(getattr(self, attr).__wrapped__, follow_wrapped=False).parameters:
-                    raise ValueError(f"{attr} not yet available")
-                    # return getattr(self, attr)(some_frame)
+                if 'frame' in inspect.signature(getattr(self, attr), follow_wrapped=False).parameters:
+                    return None
+                    # return getattr(self, attr)(frame)
+                    # TODO: make frame available
+                    # TODO: replace reflection with explicit registration
                 return getattr(self, attr)()
             else:
                 assert len(self._datas) > 0
@@ -111,8 +113,8 @@ class VObjBase(VObjBaseInterface):
             self._datas.append(None)
             self._track_length = 0
         for method_name in self._registered_names:
-            if 'frame' in inspect.signature(getattr(self, method_name).__wrapped__, follow_wrapped=False).parameters:
-                getattr(self, method_name)(frame=frame)
+            if 'frame' in inspect.signature(getattr(self, method_name), follow_wrapped=False).parameters:
+                continue
             # properties updated here
             getattr(self, method_name)()
 

--- a/vqpy/impl/vobj_base.py
+++ b/vqpy/impl/vobj_base.py
@@ -58,9 +58,6 @@ class VObjBase(VObjBaseInterface):
 
         __static_ can be used to store properties that are not time-related.
         e.g. color of object, aggregated properties
-
-        frame: the frame to be used for inference,used when the property is
-        decorated with @cross_vobj_property
         """
         # patchwork to support __static_
         if hasattr(self, '__static_' + attr):
@@ -79,7 +76,7 @@ class VObjBase(VObjBaseInterface):
                   getattr(self, '__index_' + attr) == self._ctx.frame_id):
                 return getattr(self, '__record_' + attr)
             elif attr in self._registered_names:
-                return getattr(self, attr)()
+                return getattr(self, attr)()    # TODO: test if used at all
             else:
                 assert len(self._datas) > 0
                 self._working_infers.append(attr)

--- a/vqpy/impl/vobj_base.py
+++ b/vqpy/impl/vobj_base.py
@@ -1,6 +1,6 @@
 """VObjBase implementation"""
 
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 from ..base.interface import VObjBaseInterface
 from ..function import infer
@@ -19,7 +19,7 @@ class VObjBase(VObjBaseInterface):
         self._track_length = 0
         self._datas: List[Optional[Dict]] = []
         self._registered_names: Set[str] = set()
-        self._registered_cross_vobj_names: Set[str] = set()
+        self._registered_cross_vobj_names: Dict[str, ] = {}
         self._working_infers: List[str] = []
         # NOTE: now @property instances are stored in the order of __dir__()
         for instance_name in self.__dir__():
@@ -41,7 +41,7 @@ class VObjBase(VObjBaseInterface):
     def getv(self,
              attr: str,
              index: int = -1,
-             frame: Optional[Frame] = None,
+             cross_vobj_args: Optional[Tuple] = None,
              specifications: Optional[Dict[str, str]] = None):
         """
         NOTE: Note the order in the following checking.
@@ -82,7 +82,7 @@ class VObjBase(VObjBaseInterface):
             elif attr in self._registered_names:
                 return getattr(self, attr)()
             elif attr in self._registered_cross_vobj_names:
-                return getattr(self, attr)(frame)
+                return getattr(self, attr)(*cross_vobj_args)
             else:
                 assert len(self._datas) > 0
                 self._working_infers.append(attr)
@@ -104,7 +104,7 @@ class VObjBase(VObjBaseInterface):
             else:
                 return None
 
-    def update(self, data: Optional[Dict], frame: Frame):
+    def update(self, data: Optional[Dict]):
         """Update data this frame to object"""
         if data is not None:
             self._datas.append(data.copy())

--- a/vqpy/impl/vobj_base.py
+++ b/vqpy/impl/vobj_base.py
@@ -41,7 +41,6 @@ class VObjBase(VObjBaseInterface):
     def getv(self,
              attr: str,
              index: int = -1,
-             cross_vobj_args: Optional[Tuple] = None,
              specifications: Optional[Dict[str, str]] = None):
         """
         NOTE: Note the order in the following checking.
@@ -81,8 +80,6 @@ class VObjBase(VObjBaseInterface):
                 return getattr(self, '__record_' + attr)
             elif attr in self._registered_names:
                 return getattr(self, attr)()
-            elif attr in self._registered_cross_vobj_names:
-                return getattr(self, attr)(cross_vobj_args)
             else:
                 assert len(self._datas) > 0
                 self._working_infers.append(attr)

--- a/vqpy/impl/vobj_base.py
+++ b/vqpy/impl/vobj_base.py
@@ -41,6 +41,7 @@ class VObjBase(VObjBaseInterface):
     def getv(self,
              attr: str,
              index: int = -1,
+             frame: Optional[Frame] = None,
              specifications: Optional[Dict[str, str]] = None):
         """
         NOTE: Note the order in the following checking.
@@ -59,6 +60,8 @@ class VObjBase(VObjBaseInterface):
 
         __static_ can be used to store properties that are not time-related.
         e.g. color of object, aggregated properties
+        
+        frame: the frame to be used for inference, used when the attribute is decorated with @cross_vobj_property
         """
         # patchwork to support __static_
         if hasattr(self, '__static_' + attr):
@@ -77,11 +80,9 @@ class VObjBase(VObjBaseInterface):
                   getattr(self, '__index_' + attr) == self._ctx.frame_id):
                 return getattr(self, '__record_' + attr)
             elif attr in self._registered_names:
+                # TODO: replace reflection with explicit registration
                 if 'frame' in inspect.signature(getattr(self, attr), follow_wrapped=False).parameters:
-                    return None
-                    # return getattr(self, attr)(frame)
-                    # TODO: make frame available
-                    # TODO: replace reflection with explicit registration
+                    return getattr(self, attr)(frame)
                 return getattr(self, attr)()
             else:
                 assert len(self._datas) > 0

--- a/vqpy/impl/vobj_base.py
+++ b/vqpy/impl/vobj_base.py
@@ -1,7 +1,6 @@
 """VObjBase implementation"""
 
 from typing import Dict, List, Optional
-import inspect
 
 from ..base.interface import VObjBaseInterface
 from ..function import infer
@@ -20,6 +19,7 @@ class VObjBase(VObjBaseInterface):
         self._track_length = 0
         self._datas: List[Optional[Dict]] = []
         self._registered_names: List[str] = []
+        self._registered_names_type: Dict[str, str] = {}
         self._working_infers: List[str] = []
         # NOTE: now @property instances are stored in the order of __dir__()
         for instance_name in self.__dir__():
@@ -81,7 +81,7 @@ class VObjBase(VObjBaseInterface):
                 return getattr(self, '__record_' + attr)
             elif attr in self._registered_names:
                 # TODO: replace reflection with explicit registration
-                if 'frame' in inspect.signature(getattr(self, attr), follow_wrapped=False).parameters:
+                if self._registered_names_type[attr] == 'cross_vobj_property':
                     return getattr(self, attr)(frame)
                 return getattr(self, attr)()
             else:
@@ -114,7 +114,7 @@ class VObjBase(VObjBaseInterface):
             self._datas.append(None)
             self._track_length = 0
         for method_name in self._registered_names:
-            if 'frame' in inspect.signature(getattr(self, method_name), follow_wrapped=False).parameters:
+            if self._registered_names_type[method_name] == 'cross_vobj_property':
                 continue
             # properties updated here
             getattr(self, method_name)()

--- a/vqpy/impl/vobj_base.py
+++ b/vqpy/impl/vobj_base.py
@@ -82,7 +82,7 @@ class VObjBase(VObjBaseInterface):
             elif attr in self._registered_names:
                 return getattr(self, attr)()
             elif attr in self._registered_cross_vobj_names:
-                return getattr(self, attr)(*cross_vobj_args)
+                return getattr(self, attr)(cross_vobj_args)
             else:
                 assert len(self._datas) > 0
                 self._working_infers.append(attr)

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -65,19 +65,18 @@ class VObjConstraint(VObjConstraintInterface):
             return []
         
         # retrieve properties of other VObj types that are required by @cross_vobj_property
-        # and store them in a dictionary {property_name: (list of property_values, ...)}
+        # and store them in a dictionary {property_name: List[Tuple(property1, property2, ...), ...]}
         # since all VObjs of the same type should share the same properties (even if there are multiple queries), we only need to retrieve the properties once, using information from any VObj of that type (use the first one here)
-        # TODO: change Tuple([properties of each VObj], [], ...) to List[Tuple(property_values, ...) of each VObj]
         cross_vobj_args = {}
         for cross_vobj_property in vobjs[0]._registered_cross_vobj_names.keys():
             # get the type of the other VObj and the properties required by the @cross_vobj_property
             other_vobj_type, other_vobj_input_fields = vobjs[0]._registered_cross_vobj_names[cross_vobj_property]
             other_vobjs = frame.get_tracked_vobjs(other_vobj_type)
             properties = []
-            for input_field in other_vobj_input_fields:
-                properties.append([vobj.getv(input_field) for vobj in other_vobjs])
-            cross_vobj_args[cross_vobj_property] = tuple(properties)
-            
+            for other_vobj in other_vobjs:
+                properties.append(tuple(other_vobj.getv(input_field) for input_field in other_vobj_input_fields))
+            cross_vobj_args[cross_vobj_property] = properties
+        
         ret: List[VObjBaseInterface] = []
         for obj in vobjs:
             ok = True

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -114,6 +114,8 @@ class VObjConstraint(VObjConstraintInterface):
     def _compute_cross_vobj_property(
         self, frame: FrameInterface, vobjs: VObjBaseInterface, conditions
     ) -> None:
+        """Compute cross_vobj_property's used in the conditions for the given
+        VObjs"""
         if len(vobjs) == 0:
             return
 

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -79,7 +79,13 @@ class VObjConstraint(VObjConstraintInterface):
                 properties.append(tuple(other_vobj.getv(input_field) for input_field in other_vobj_input_fields))
             cross_vobj_args[cross_vobj_property] = properties
        
-        # TODO: move cross_vobj_property's computation to here, also removes the need for passing cross_vobj_args to getv and continuing
+        # for each vobj, compute value of cross_vobj_property
+        # no longer need to pass cross_vobj_arg to getv and continuing
+        # In fact, all properties should be computed here, getv should only be responsible for retrieving the property value (instead of doing the computation when value is absent). This, however, requires building dependency graph for all vobj properties, we leave it for future work.
+        for obj in vobjs:
+            for property_name, func in self.filter_cons.items():
+                if property_name in obj._registered_cross_vobj_names.keys():
+                    getattr(obj, property_name)(cross_vobj_args[property_name])
         
         ret: List[VObjBaseInterface] = []
         for obj in vobjs:
@@ -92,10 +98,10 @@ class VObjConstraint(VObjConstraintInterface):
                 if type(func) == continuing:
                     # use property name to access the corresponding property values
                     # if property is not decorated with @cross_vobj_property, just use None (will be ignored if the property is decorated with @property)
-                    ok = func(obj, property_name, cross_vobj_args = cross_vobj_args.get(property_name, None))
+                    ok = func(obj, property_name)
                 else:
                     # same for getv
-                    it = obj.getv(property_name, cross_vobj_args = cross_vobj_args.get(property_name, None))
+                    it = obj.getv(property_name)
                     if it is None or not func(it):
                         ok = False
                         break

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -64,11 +64,13 @@ class VObjConstraint(VObjConstraintInterface):
         if len(vobjs) == 0:
             return []
         
-        # retrieve properties of other VObj types that are required by @cross_vobj_property
+        # retrieve properties of other VObj types that are 1. required by @cross_vobj_property 2. in filter_cons
         # and store them in a dictionary {property_name: List[Tuple(property1, property2, ...), ...]}
         # since all VObjs of the same type should share the same properties (even if there are multiple queries), we only need to retrieve the properties once, using information from any VObj of that type (use the first one here)
         cross_vobj_args = {}
         for cross_vobj_property in vobjs[0]._registered_cross_vobj_names.keys():
+            if cross_vobj_property not in self.filter_cons.keys():
+                continue
             # get the type of the other VObj and the properties required by the @cross_vobj_property
             other_vobj_type, other_vobj_input_fields = vobjs[0]._registered_cross_vobj_names[cross_vobj_property]
             other_vobjs = frame.get_tracked_vobjs(other_vobj_type)
@@ -76,6 +78,8 @@ class VObjConstraint(VObjConstraintInterface):
             for other_vobj in other_vobjs:
                 properties.append(tuple(other_vobj.getv(input_field) for input_field in other_vobj_input_fields))
             cross_vobj_args[cross_vobj_property] = properties
+       
+        # TODO: move cross_vobj_property's computation to here, also removes the need for passing cross_vobj_args to getv and continuing
         
         ret: List[VObjBaseInterface] = []
         for obj in vobjs:

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -59,7 +59,7 @@ class VObjConstraint(VObjConstraintInterface):
                 if type(func) == continuing:
                     ok = func(obj, property_name, frame)
                 else:
-                    it = obj.getv(property_name, -1, frame)
+                    it = obj.getv(property_name, frame=frame)
                     if it is None or not func(it):
                         ok = False
                         break

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -70,7 +70,9 @@ class VObjConstraint(VObjConstraintInterface):
         vobjs = frame.get_tracked_vobjs(vobj_type)
 
         # compute cross_vobj_property's in the VObjs of the desired type
-        self._compute_cross_vobj_property(frame, vobjs, self.filter_cons)
+        self._compute_cross_vobj_property(
+            frame, vobjs, self.filter_cons.keys()
+        )
 
         ret: List[VObjBaseInterface] = []
         for obj in vobjs:
@@ -106,13 +108,15 @@ class VObjConstraint(VObjConstraintInterface):
         # compute cross_vobj_property's in the filtered VObjs, for potential
         # usage in select_cons
         # select_cons are provided so only those being used will be computed
-        self._compute_cross_vobj_property(frame, filtered, self.select_cons)
+        self._compute_cross_vobj_property(
+            frame, filtered, self.select_cons.keys() - self.filter_cons.keys()
+        )
         selected = self.select(filtered)
         filtered_ids = [obj.getv("track_id") for obj in filtered]
         return selected, filtered_ids
 
     def _compute_cross_vobj_property(
-        self, frame: FrameInterface, vobjs: VObjBaseInterface, conditions
+        self, frame: FrameInterface, vobjs: VObjBaseInterface, condition_names
     ) -> None:
         """Compute cross_vobj_property's used in the conditions for the given
         VObjs"""
@@ -139,7 +143,7 @@ class VObjConstraint(VObjConstraintInterface):
         for cross_vobj_property in \
                 vobjs[0]._registered_cross_vobj_names.keys():
             # only compute properties used in the conditions
-            if cross_vobj_property not in conditions.keys():
+            if cross_vobj_property not in condition_names:
                 continue
             other_vobj_type, other_vobj_input_fields = \
                 vobjs[0]._registered_cross_vobj_names[cross_vobj_property]
@@ -156,6 +160,6 @@ class VObjConstraint(VObjConstraintInterface):
 
         # for each vobj, compute value of cross_vobj_property
         for obj in vobjs:
-            for property_name, _ in conditions.items():
+            for property_name in condition_names:
                 if property_name in obj._registered_cross_vobj_names.keys():
                     getattr(obj, property_name)(cross_vobj_args[property_name])

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Callable, Dict, List, Optional
-from ..base.interface import VObjBaseInterface, VObjConstraintInterface
+from ..base.interface import VObjBaseInterface, VObjConstraintInterface, FrameInterface
 from ..utils.filters import continuing
 
 
@@ -48,7 +48,7 @@ class VObjConstraint(VObjConstraintInterface):
         select_cons = self.select_cons.copy()
         return VObjConstraint(filter_cons, select_cons, self.filename)
 
-    def filter(self, objs: List[VObjBaseInterface]) -> List[VObjBaseInterface]:
+    def filter(self, objs: List[VObjBaseInterface], frame: FrameInterface) -> List[VObjBaseInterface]:
         """filter the list of vobjects from the constraint"""
         ret: List[VObjBaseInterface] = []
         for obj in objs:
@@ -57,9 +57,9 @@ class VObjConstraint(VObjConstraintInterface):
                 # patch work to support vqpy.utils.continuing since Vobj needs
                 # to be passed as an argument
                 if type(func) == continuing:
-                    ok = func(obj, property_name)
+                    ok = func(obj, property_name, frame)
                 else:
-                    it = obj.getv(property_name)
+                    it = obj.getv(property_name, -1, frame)
                     if it is None or not func(it):
                         ok = False
                         break
@@ -73,10 +73,10 @@ class VObjConstraint(VObjConstraintInterface):
                  for key, postproc in self.select_cons.items()}
                 for x in objs]
 
-    def apply(self, vobjs: List[VObjBaseInterface]) -> List[Dict]:
+    def apply(self, vobjs: List[VObjBaseInterface], frame: FrameInterface) -> List[Dict]:
         """apply the constraint on a list of VObj instances"""
         # TODO: optimize the procedure
-        filtered = self.filter(vobjs)
+        filtered = self.filter(vobjs, frame)
         selected = self.select(filtered)
         filtered_ids = [obj.getv("track_id") for obj in filtered]
         return selected, filtered_ids

--- a/vqpy/impl/vobj_constraint.py
+++ b/vqpy/impl/vobj_constraint.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from typing import Callable, Dict, List, Optional
-from ..base.interface import VObjBaseInterface, VObjConstraintInterface, FrameInterface
+from ..base.interface import \
+    VObjBaseInterface, VObjConstraintInterface, FrameInterface
 from ..utils.filters import continuing
 
 
@@ -48,35 +49,42 @@ class VObjConstraint(VObjConstraintInterface):
         select_cons = self.select_cons.copy()
         return VObjConstraint(filter_cons, select_cons, self.filename)
 
-    def filter(self, frame) -> List[VObjBaseInterface]:
+    def filter(self, frame: FrameInterface) -> List[VObjBaseInterface]:
         """filter the list of vobjects from the constraint"""
         # Some assumptions:
-        # - each query will only filter one type of VObj (called desired VObj type)
-        # - query will implement such filter by filtering on the "__class__" property
-        
+        # - each query only filters one type of VObj (the desired VObj type)
+        # - queries will implement such filtering of a single type of VObj
+        #   by adding restriction on the "__class__" property
+
         # function used in query to select the desired VObjs
         filter_func = self.filter_cons["__class__"]
-        # get the first VObj type that satisfies the filter function, should be the desired VObj type
-        vobj_type = next((vobj_type for vobj_type in frame.vobjs.keys() if filter_func(vobj_type)), None)
+        # get the first VObj type that satisfies the filter function,
+        # should be the desired VObj type
+        vobj_type = next((
+                vobj_type
+                for vobj_type in frame.vobjs.keys() if filter_func(vobj_type)
+            ),
+            None
+        )
         # all VObjs of the desired type
         vobjs = frame.get_tracked_vobjs(vobj_type)
-        
+
+        # compute cross_vobj_property's in the VObjs of the desired type
         self._compute_cross_vobj_property(frame, vobjs, self.filter_cons)
-        
+
         ret: List[VObjBaseInterface] = []
         for obj in vobjs:
             ok = True
             for property_name, func in self.filter_cons.items():
-                # patch work to support vqpy.utils.continuing since Vobj needs
-                # to be passed as an argument
                 if property_name == "__class__":
+                    # skip filters about "__class__" since we already used it
+                    # to only include VObjs of the desired type
                     continue
                 if type(func) == continuing:
-                    # use property name to access the corresponding property values
-                    # if property is not decorated with @cross_vobj_property, just use None (will be ignored if the property is decorated with @property)
+                    # patch work to support vqpy.utils.continuing since
+                    # VObj and the property name need to be passed as arguments
                     ok = func(obj, property_name)
                 else:
-                    # same for getv
                     it = obj.getv(property_name)
                     if it is None or not func(it):
                         ok = False
@@ -91,31 +99,57 @@ class VObjConstraint(VObjConstraintInterface):
                  for key, postproc in self.select_cons.items()}
                 for x in objs]
 
-    def apply(self, frame) -> List[Dict]:
+    def apply(self, frame: FrameInterface) -> List[Dict]:
         """apply the constraint on a list of VObj instances"""
         # TODO: optimize the procedure
         filtered = self.filter(frame)
+        # compute cross_vobj_property's in the filtered VObjs, for potential
+        # usage in select_cons
+        # select_cons are provided so only those being used will be computed
         self._compute_cross_vobj_property(frame, filtered, self.select_cons)
         selected = self.select(filtered)
         filtered_ids = [obj.getv("track_id") for obj in filtered]
         return selected, filtered_ids
 
-    def _compute_cross_vobj_property(self, frame, vobjs, conditions) -> None:
+    def _compute_cross_vobj_property(
+        self, frame: FrameInterface, vobjs: VObjBaseInterface, conditions
+    ) -> None:
         if len(vobjs) == 0:
             return
 
-        # retrieve properties of other VObj types that are 1. required by @cross_vobj_property 2. in filter/select_cons
-        # and store them in a dictionary {property_name: List[Tuple(property1, property2, ...), ...]}
-        # since all VObjs of the same type should share the same properties (even if there are multiple queries), we only need to retrieve the properties once, using information from any VObj of that type (use the first one here)
+        # Retrieve properties of other VObjs that are
+        # 1. required by @cross_vobj_property 2. used in filter/select_cons
+        # and store them in a dictionary
+        # Dict{
+        #     cross_vobj_property_name: \
+        #         List[
+        #             Tuple(required vobj1's property1, property2, ...),
+        #             Tuple(required vobj2's properties),
+        #             ...
+        #         ],
+        #     ...
+        # }
+        # Since all VObjs of the same type should share the same properties
+        # within each query, we only need to retrieve the values of the
+        # properties once, using _registered_cross_vobj_names from any VObj
+        # of that type (use the first one here)
         cross_vobj_args = {}
-        for cross_vobj_property in vobjs[0]._registered_cross_vobj_names.keys():
+        for cross_vobj_property in \
+                vobjs[0]._registered_cross_vobj_names.keys():
+            # only compute properties used in the conditions
             if cross_vobj_property not in conditions.keys():
                 continue
-            other_vobj_type, other_vobj_input_fields = vobjs[0]._registered_cross_vobj_names[cross_vobj_property]
+            other_vobj_type, other_vobj_input_fields = \
+                vobjs[0]._registered_cross_vobj_names[cross_vobj_property]
             other_vobjs = frame.get_tracked_vobjs(other_vobj_type)
             properties = []
             for other_vobj in other_vobjs:
-                properties.append(tuple(other_vobj.getv(input_field) for input_field in other_vobj_input_fields))
+                properties.append(
+                    tuple(
+                        other_vobj.getv(input_field)
+                        for input_field in other_vobj_input_fields
+                    )
+                )
             cross_vobj_args[cross_vobj_property] = properties
 
         # for each vobj, compute value of cross_vobj_property

--- a/vqpy/utils/filters.py
+++ b/vqpy/utils/filters.py
@@ -33,14 +33,13 @@ class continuing:
         # use name given as property name of time periods
         self.name = name
 
-    def __call__(self, obj, property_name, cross_vobj_args: Optional[Tuple] = None):
+    def __call__(self, obj, property_name):
         cur_frame = obj._ctx.frame_id
         # threshold should be set to the same as tracker's threshold of marking
         # track as lost
         # Currently set to equal ByteTrack's threshold
-        # Optional argument cross_vobj_args is for properties decorated with @cross_vobj_property
         threshold = int(obj._ctx.fps / 30.0 * 30)
-        if self.condition(obj.getv(property_name, cross_vobj_args=cross_vobj_args)):
+        if self.condition(obj.getv(property_name)):
             # get the start and end of the potentially continuing period
             period_start = obj.getv(f"{self.name}_start")
             period_end = obj.getv(f"{self.name}_end")

--- a/vqpy/utils/filters.py
+++ b/vqpy/utils/filters.py
@@ -38,7 +38,7 @@ class continuing:
         # Currently set to equal ByteTrack's threshold
         # Optional frame argument for properties decorated with @cross_vobj_property
         threshold = int(obj._ctx.fps / 30.0 * 30)
-        if self.condition(obj.getv(property_name, -1, frame)):
+        if self.condition(obj.getv(property_name, frame=frame)):
             # get the start and end of the potentially continuing period
             period_start = obj.getv(f"{self.name}_start")
             period_end = obj.getv(f"{self.name}_end")

--- a/vqpy/utils/filters.py
+++ b/vqpy/utils/filters.py
@@ -31,13 +31,14 @@ class continuing:
         # use name given as property name of time periods
         self.name = name
 
-    def __call__(self, obj, property_name):
+    def __call__(self, obj, property_name, frame=None):
         cur_frame = obj._ctx.frame_id
         # threshold should be set to the same as tracker's threshold of marking
         # track as lost
         # Currently set to equal ByteTrack's threshold
+        # Optional frame argument for properties decorated with @cross_vobj_property
         threshold = int(obj._ctx.fps / 30.0 * 30)
-        if self.condition(obj.getv(property_name)):
+        if self.condition(obj.getv(property_name, -1, frame)):
             # get the start and end of the potentially continuing period
             period_start = obj.getv(f"{self.name}_start")
             period_end = obj.getv(f"{self.name}_end")

--- a/vqpy/utils/filters.py
+++ b/vqpy/utils/filters.py
@@ -1,5 +1,3 @@
-from typing import List, Optional, Tuple
-
 class continuing:
     """Checks whether the condition function continues to be true
     for a certain duration.

--- a/vqpy/utils/filters.py
+++ b/vqpy/utils/filters.py
@@ -1,3 +1,5 @@
+from typing import List, Optional, Tuple
+
 class continuing:
     """Checks whether the condition function continues to be true
     for a certain duration.
@@ -31,14 +33,14 @@ class continuing:
         # use name given as property name of time periods
         self.name = name
 
-    def __call__(self, obj, property_name, frame=None):
+    def __call__(self, obj, property_name, cross_vobj_args: Optional[Tuple] = None):
         cur_frame = obj._ctx.frame_id
         # threshold should be set to the same as tracker's threshold of marking
         # track as lost
         # Currently set to equal ByteTrack's threshold
-        # Optional frame argument for properties decorated with @cross_vobj_property
+        # Optional argument cross_vobj_args is for properties decorated with @cross_vobj_property
         threshold = int(obj._ctx.fps / 30.0 * 30)
-        if self.condition(obj.getv(property_name, frame=frame)):
+        if self.condition(obj.getv(property_name, cross_vobj_args=cross_vobj_args)):
             # get the start and end of the potentially continuing period
             period_start = obj.getv(f"{self.name}_start")
             period_end = obj.getv(f"{self.name}_end")


### PR DESCRIPTION
## Why this change?
Remove reference to Frame in VObj instances, which was introduced as a tempory work around to support `@cross_vobj_property`.

## What does this PR include?

- fix unattended baggage example
  Decorate property function `owner` with `@stateful`. Didn't cause any problems in unattended baggage example:

  If `owner` was not decorated to be a stateful property, previous implmentation of `getv` will always return `None` when requesting past `owner` (instead of giving an error that no such stateful property exist). This return value `None` was then interpreted as previous owner does not exist, not affecting computation of Baggage's owner in the current frame.

  `getv`'s behavior will be fixed in #32.

- remove reference to Frame in VObj instances

  Frame will be passed to `VObjConstraint.apply()` to retrieve information (`cross_vobj_arg`) needed to compute cross vobj properties (computation is in `VObjConstraint._compute_cross_vobj_property`).

  This also means computation of cross vobj properties will be delayed until actual filter/select condition. (Yet to create dependency graph for VObj properties.)

  Includes necessary internal interface changes:

  - only need to pass frame to `query.vqpy_update`
  - `tracker.update` only needs to return frame

- add functionality of `@property` to `@cross_vobj_property` so `@property` is not needed when creating cross vobj properties

  Uses the same logic of avoiding repeated computation as `@property`.

- change interface requirement for property function to be decorated with `@cross_vobj_property`

  See  [User API changes](#user-api-changes) for details.

- register `@cross_vobj_property` and `@property` to VObj explicitly, in sets `_registered_name, _registered_cross_vobj_names`

## User API changes

- No longer need to add `@property` before `@cross_vobj_property` to create cross vobj properties in VObj

- Interface requirement for property function to be decorated with `@cross_vobj_property` changed

  The property function being decorated should accept two arguments: `self` and `cross_vobj_arg` (positional).

  During execution, VQPy will pass `cross_vobj_arg`, a list of properties of VObjs of specified type, to the property function being decorated.

  `cross_vobj_arg` has structure: `List[Tuple(property1, property2, ...) for vobj1, Tuple for vobj2, ...]`, where `property1, property2` are values of property names listed in `vobj_input_fields`, in order; `vobj1, vobj2` are VObjs of type `vobj_type`.

## New dependencies included
None