### PR TITLE
Change data for people counting example and built-in `direction`

### DIFF
--- a/examples/people_counting/yolox_detector.py
+++ b/examples/people_counting/yolox_detector.py
@@ -28,7 +28,7 @@ class YOLOXDetector(DetectorBase):
         exp = get_exp(None, "yolox_x")
         exp.test_conf = 0.3
         exp.nmsthre = 0.3
-        exp.test_size = (640, 640)
+        exp.test_size = (480, 854)
 
         model = exp.get_model()
         model_info = get_model_info(model, exp.test_size)

--- a/vqpy/base/query.py
+++ b/vqpy/base/query.py
@@ -41,7 +41,7 @@ class QueryBase(object):
             total_vobj_num_data = {
                 OUTPUT_TOTAL_VOBJ_NUM_NAME: len(self._total_ids)
             }
-            if frame_id == 1:
+            if frame_id == 0:
                 self._query_data = [total_vobj_num_data]
             else:
                 assert OUTPUT_TOTAL_VOBJ_NUM_NAME in self._query_data[0]

--- a/vqpy/utils/predicate_funcs.py
+++ b/vqpy/utils/predicate_funcs.py
@@ -1,10 +1,28 @@
 
 def within_regions(regions):
+    """
+    A predicate function that check whether the coordinate is in the regions.
+    This function should be used as the value of `filter_cons` dictionary.
+    and its key should be a coordinate property. The function will return true
+    if the computed coordinate values of the property is in the regions.
+
+    :param regions: one region or a list of regions, where region should be
+            a list of coordinates and coordinates is a tuple of (x, y).
+            The coordinates should be the exterior points of a Polygon.
+
+    """
+    if type(regions[0]) is tuple:
+        regions = [regions]
+
     def point_within_regions(coordinate):
         from shapely.geometry import Point, Polygon
         point = Point(coordinate)
         for region in regions:
             poly = Polygon(region)
+            if poly.area <= 0:
+                raise ValueError(f"The area with in region {region} is less"
+                                 f"than zero. Please check your region"
+                                 f"coordinates.")
             if point.within(poly):
                 return True
         return False


### PR DESCRIPTION
## Why this change?
1. We used an internal video to test people counting, while it cannot be accessed by users. Find another public video data to count pedestrians. A new public video data can be downloaded [here](https://www.kaggle.com/datasets/jayitabhattacharyya/social-distance)
3. Move the `direction` property into property lib
4. `within_regions` can accept a single region(a list of coordinates)

## What does this PR include?
1. Tune `REGION` for the new dataset. 
2. Enhance `within_regions` interface to accept a single region input. Internally, we will convert a single region to a list of regions. API doc for `within_regions` has also be added.
3. Move the `direction` property inside. Since it is complicated mainly for debugging, user may get confused if it is in the example.

## User API changes
1. `within_regions(regions)`, `regions` can be either one region or a list of regions
2. user can directly use `direction` property in their query

## How did I test the PR?
With people counting example 

## New dependencies included
No

## Related issue
https://github.com/VQPy/VQPy-internal/issues/21